### PR TITLE
Fix Windows start scripts to have a valid classpath

### DIFF
--- a/changelog/@unreleased/pr-4.v2.yml
+++ b/changelog/@unreleased/pr-4.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix Windows start scripts to have a valid classpath
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/4
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/4

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishApplicationDistPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishApplicationDistPlugin.java
@@ -59,7 +59,7 @@ public class ExternalPublishApplicationDistPlugin implements Plugin<Project> {
             CreateStartScripts createStartScripts = (CreateStartScripts) task;
 
             String windowsScript = GFileUtils.readFile(createStartScripts.getWindowsScript());
-            String modified = windowsScript.replaceFirst("(set CLASSPATH=%APP_HOME%\\\\lib\\\\).*", "$1");
+            String modified = windowsScript.replaceFirst("(set CLASSPATH=%APP_HOME%\\\\lib\\\\).*", "$1*");
             GFileUtils.writeFile(modified, createStartScripts.getWindowsScript(), StandardCharsets.UTF_8.toString());
         }
     }

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -256,7 +256,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         ArchiverFactory.createArchiver(ArchiveFormat.TAR)
                 .extract(new GzipCompressorInputStream(new FileInputStream(applicationDistTar)), extracted)
         new File(extracted, "application-dist-version/bin/application-dist.bat").text
-                .contains('set CLASSPATH=%APP_HOME%\\lib\\\r\n')
+                .contains('set CLASSPATH=%APP_HOME%\\lib\\*\r\n')
 
         verifyPomFile(gnv, 'application-dist')
     }


### PR DESCRIPTION
I was helping some Windows users deal with failures of Conjure tasks on their machines, which led me here.

The `lib\` folder being passed in here is a folder containing jars in a flat structure. The [format for adding such a folder to the classpath](https://en.wikipedia.org/wiki/Classpath#Adding_all_JAR_files_in_a_directory) is `lib\*`, not `lib\`, which denotes a folder containing a nested directory structure with .class files.