### PR TITLE
Fix trial publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ buildscript {
 }
 
 apply plugin: 'com.palantir.external-publish-gradle-plugin'
+// So we get publishToMavenLocal
+apply plugin: 'maven-publish'
 
 repositories {
     gradlePluginPortal()


### PR DESCRIPTION
## Before this PR
The `trial-publish` circle job runs `publishToMavenLocal`, which does not exist in this repo.

Additionally, publishToMavenLocal cannot be used for local testing.

## After this PR
Fix these issues.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
