### PR TITLE
Add publishing excavator to list for trying publishing on branches

### DIFF
--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -111,7 +111,7 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
 
     private void alwaysRunPublishIfOnExcavatorUpgradeBranch() {
         boolean isPublishingExcavatorBranch = EnvironmentVariables.envVarOrFromTestingProperty(project, "CIRCLE_BRANCH")
-                .filter(name -> PUBLISHING_UPGRADE_EXCAVATOR_BRANCH_NAMES.contains(name))
+                .filter(PUBLISHING_UPGRADE_EXCAVATOR_BRANCH_NAMES::contains)
                 .isPresent();
 
         // If we're upgrading publishing logic via excavator using a known excavator PR, ensure we test the publish

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -16,9 +16,11 @@
 
 package com.palantir.gradle.externalpublish;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import nebula.plugin.info.scm.ScmInfoPlugin;
 import nebula.plugin.publishing.maven.MavenBasePublishPlugin;
@@ -39,6 +41,10 @@ import org.gradle.plugins.signing.SigningExtension;
 import org.gradle.plugins.signing.SigningPlugin;
 
 final class ExternalPublishBasePlugin implements Plugin<Project> {
+    private static final Set<String> PUBLISHING_UPGRADE_EXCAVATOR_BRANCH_NAMES = Collections.unmodifiableSet(
+            Stream.of("roomba/external-publish-plugin-migration", "roomba/latest-oss-publishing")
+                    .collect(Collectors.toSet()));
+
     private final Set<String> sonatypePublicationNames = new HashSet<>();
 
     private Project project;
@@ -105,7 +111,8 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
 
     private void alwaysRunPublishIfOnExcavatorUpgradeBranch() {
         boolean isPublishingExcavatorBranch = EnvironmentVariables.envVarOrFromTestingProperty(project, "CIRCLE_BRANCH")
-                .equals(Optional.of("roomba/external-publish-plugin-migration"));
+                .filter(name -> PUBLISHING_UPGRADE_EXCAVATOR_BRANCH_NAMES.contains(name))
+                .isPresent();
 
         // If we're upgrading publishing logic via excavator using a known excavator PR, ensure we test the publish
         // even if the publish command is not called. However, don't force every single PR to do the publish that


### PR DESCRIPTION
## Before this PR
We only test publishing to sonatype before automerging for migration excavator branches, but not the publishing plugin upgrade excavator.

## After this PR
We test publishing on the plugin upgrade excavator too.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
