### PR TITLE
Remove publishing from feature branches

### DIFF
--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -16,11 +16,9 @@
 
 package com.palantir.gradle.externalpublish;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import nebula.plugin.info.scm.ScmInfoPlugin;
 import nebula.plugin.publishing.maven.MavenBasePublishPlugin;
@@ -36,7 +34,6 @@ import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
-import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.plugins.signing.SigningExtension;
 import org.gradle.plugins.signing.SigningPlugin;
 
@@ -87,8 +84,10 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
                         "The com.palantir.external-publish plugin must be applied to the root project "
                                 + "*before* this plugin is evaluated"));
 
-        project.getTasks().named("publish").configure(publish -> {
-            publish.dependsOn(rootPlugin.sonatypeFinishingTask());
+        rootPlugin.sonatypeFinishingTask().ifPresent(sonatypeFinishingTask -> {
+            project.getTasks().named("publish").configure(publish -> {
+                publish.dependsOn(sonatypeFinishingTask);
+            });
         });
     }
 

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishRootPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishRootPlugin.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.externalpublish;
 import io.github.gradlenexus.publishplugin.NexusPublishExtension;
 import io.github.gradlenexus.publishplugin.NexusPublishPlugin;
 import java.time.Duration;
+import java.util.Optional;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -61,11 +62,13 @@ public class ExternalPublishRootPlugin implements Plugin<Project> {
                 .configure(CircleCiContextDeadlineAvoidance::avoidHittingCircleCiContextDeadlineByPrintingEverySoOften);
     }
 
-    public final TaskProvider<?> sonatypeFinishingTask() {
+    public final Optional<TaskProvider<?>> sonatypeFinishingTask() {
         boolean isTagBuild = EnvironmentVariables.isTagBuild(rootProject);
 
-        return rootProject
-                .getTasks()
-                .named(isTagBuild ? "closeAndReleaseSonatypeStagingRepository" : "closeSonatypeStagingRepository");
+        if (!isTagBuild) {
+            return Optional.empty();
+        }
+
+        return Optional.of(rootProject.getTasks().named("closeAndReleaseSonatypeStagingRepository"));
     }
 }

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -407,7 +407,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         errorMessage.contains 'dirty'
     }
 
-    def 'does close but not release staging sonatype repo if not on a tag build'() {
+    def 'does not close or release staging sonatype repo if not on a tag build'() {
         setup:
         allPublishProjects()
 
@@ -415,7 +415,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         def stdout = runSuccessfullyWithSigning('publish', '--dry-run').standardOutput
 
         then:
-        stdout.contains(':closeSonatypeStagingRepository')
+        !stdout.contains(':closeSonatypeStagingRepository')
         !stdout.contains(':releaseSonatypeStagingRepository')
     }
 
@@ -429,25 +429,6 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         then:
         stdout.contains(':closeSonatypeStagingRepository')
         stdout.contains(':releaseSonatypeStagingRepository')
-    }
-
-    def 'runs publish tasks as a dependency of check on upgrade excavator'() {
-        setup:
-        allPublishProjects()
-
-        when:
-        def stdout = runSuccessfullyWithSigning(
-                '--dry-run', '-P__TESTING_CIRCLE_BRANCH=roomba/external-publish-plugin-migration', 'check')
-                .standardOutput
-
-        println stdout
-
-        then:
-        stdout.contains(':initializeSonatypeStagingRepository SKIPPED')
-        stdout.contains(':jar:publishMavenPublicationToSonatypeRepository SKIPPED')
-        stdout.contains(':dist:publishDistPublicationToSonatypeRepository SKIPPED')
-        stdout.contains(':closeSonatypeStagingRepository SKIPPED')
-        !stdout.contains(':releaseSonatypeStagingRepository SKIPPED')
     }
 
     def 'does not run publish tasks as a dependency of check on normal run'() {

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -356,12 +356,13 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
     }
 
     @Unroll
-    def 'publish task for #type depends on publishing to sonatype'() {
+    def 'publish task for #type depends on publishing to sonatype on tag builds'() {
         setup:
         publishProject(type)
 
         when:
-        def stdout = runSuccessfullyWithSigning('--dry-run', ":${type}:publish").standardOutput
+        def stdout = runSuccessfullyWithSigning(
+                '--dry-run', "-P__TESTING_CIRCLE_TAG=tag", ":${type}:publish").standardOutput
 
         then:
         stdout.find ":${type}:publish.*PublicationToSonatypeRepository SKIPPED"

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -408,6 +408,9 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
     }
 
     def 'does not close or release staging sonatype repo if not on a tag build'() {
+        // See https://issues.sonatype.org/browse/OSSRH-65523?focusedCommentId=1046249#comment-1046249 for why we can't
+        // exercise the publishing codepath on develop - basically it overwhelms Sonatype and harms other users (note
+        // there is no per user rate limiting, so it's possible for us to harm everyone else).
         setup:
         allPublishProjects()
 


### PR DESCRIPTION
We received a complaint that we publish too frequently to maven central. I suspect this is due to the fact that excavators like to push commits frequently. In order to be good internet citizens, we should publish to maven local on our trial branches and only exercise full publishing on tags.

// https://issues.sonatype.org/browse/OSSRH-65523
