### PR TITLE
Actually stop creating Sonatype repos on develop

### DIFF
--- a/changelog/@unreleased/pr-12.v2.yml
+++ b/changelog/@unreleased/pr-12.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensure a Sonatype staging repo is not created at all or published to when on a branch.
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/12

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -98,7 +98,7 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
                     boolean isSonatypePublish = sonatypePublicationNames.contains(
                             publishTask.getPublication().getName());
 
-                    return isSonatypePublish && EnvironmentVariables.isTagBuild(project) ;
+                    return isSonatypePublish && EnvironmentVariables.isTagBuild(project);
                 }
 
                 return true;

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -95,8 +95,10 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
         project.getTasks().withType(PublishToMavenRepository.class).configureEach(publishTask -> {
             publishTask.onlyIf(_ignored -> {
                 if (publishTask.getRepository().getName().equals("sonatype")) {
-                    return sonatypePublicationNames.contains(
+                    boolean isSonatypePublish = sonatypePublicationNames.contains(
                             publishTask.getPublication().getName());
+
+                    return isSonatypePublish && EnvironmentVariables.isTagBuild(project) ;
                 }
 
                 return true;

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishRootPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishRootPlugin.java
@@ -53,6 +53,7 @@ public class ExternalPublishRootPlugin implements Plugin<Project> {
         TaskProvider<?> checkVersion = rootProject.getTasks().register("checkVersion", CheckVersionTask.class);
 
         rootProject.getTasks().named("initializeSonatypeStagingRepository").configure(initialize -> {
+            initialize.onlyIf(_ignored -> EnvironmentVariables.isTagBuild(rootProject));
             initialize.dependsOn(checkSigningKey, checkVersion);
         });
 


### PR DESCRIPTION
## Before this PR
In #11, we stop closing repos on branches, but we still create and then publish to a Sonatype staging repo, just don't close it.

## After this PR
==COMMIT_MSG==
Ensure a Sonatype staging repo is not created at all or published to when on a branch.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
