### PR TITLE
Fix develop test failures

### DIFF
--- a/src/main/java/com/palantir/gradle/externalpublish/EnvironmentVariables.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/EnvironmentVariables.java
@@ -25,6 +25,10 @@ final class EnvironmentVariables {
     static Optional<String> envVarOrFromTestingProperty(Project project, String envVar) {
         Optional<String> fromTestingProp = Optional.ofNullable((String) project.findProperty("__TESTING_" + envVar));
 
+        if (fromTestingProp.equals(Optional.of("unset"))) {
+            return Optional.empty();
+        }
+
         if (fromTestingProp.isPresent()) {
             return fromTestingProp;
         }

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -378,7 +378,12 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         publishProject(type)
 
         when:
-        def errorMessage = runTasksWithFailure(":${type}:publish").failure.cause.cause.message
+        def errorMessage = runTasksWithFailure(
+                        ":${type}:publish",
+                        '-P__TESTING_GPG_SIGNING_KEY=unset',
+                        '-P__TESTING_GPG_SIGNING_KEY_ID=unset',
+                        '-P__TESTING_GPG_SIGNING_KEY_PASSWORD=unset',
+                ).failure.cause.cause.message
 
         then:
         errorMessage == 'The required environment variables to sign the release could not be found. ' +


### PR DESCRIPTION
## Before this PR
Develop is broken: https://app.circleci.com/pipelines/github/palantir/gradle-external-publish-plugin/52/workflows/d3a468fe-c6f6-4255-9622-f4f0911d0365/jobs/301

Looks like creds were now injected into the build which fails the test.

## After this PR
Develop is fixed.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
