### PR TITLE
Ensure signing keys are not checked on forks

### DIFF
--- a/changelog/@unreleased/pr-47.v2.yml
+++ b/changelog/@unreleased/pr-47.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Do not check for Sonatype signing key environment variables on fork
+    builds.
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/47

--- a/src/main/java/com/palantir/gradle/externalpublish/EnvironmentVariables.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/EnvironmentVariables.java
@@ -41,4 +41,8 @@ final class EnvironmentVariables {
                 .filter(tag -> !tag.isEmpty())
                 .isPresent();
     }
+
+    static boolean isFork(Project project) {
+        return envVarOrFromTestingProperty(project, "CIRCLE_PR_USERNAME").isPresent();
+    }
 }

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishRootPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishRootPlugin.java
@@ -49,12 +49,17 @@ public class ExternalPublishRootPlugin implements Plugin<Project> {
             repo.getPassword().set(System.getenv("SONATYPE_PASSWORD"));
         });
 
-        TaskProvider<?> checkSigningKey = rootProject.getTasks().register("checkSigningKey", CheckSigningKeyTask.class);
+        TaskProvider<?> checkSigningKeyTask = rootProject
+                .getTasks()
+                .register("checkSigningKey", CheckSigningKeyTask.class, checkSigningKey -> {
+                    checkSigningKey.onlyIf(_ignored -> !EnvironmentVariables.isFork(rootProject));
+                });
+
         TaskProvider<?> checkVersion = rootProject.getTasks().register("checkVersion", CheckVersionTask.class);
 
         rootProject.getTasks().named("initializeSonatypeStagingRepository").configure(initialize -> {
             initialize.onlyIf(_ignored -> EnvironmentVariables.isTagBuild(rootProject));
-            initialize.dependsOn(checkSigningKey, checkVersion);
+            initialize.dependsOn(checkSigningKeyTask, checkVersion);
         });
 
         rootProject

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -41,7 +41,6 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
                 repositories {
                     gradlePluginPortal()
                     mavenCentral()
-                    maven { url 'https://dl.bintray.com/palantir/releases/' }
                 }
                 
                 dependencies {
@@ -58,7 +57,6 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
                 
                 repositories {
                     mavenCentral()
-                    maven { url 'https://dl.bintray.com/palantir/releases/' }
                 }
             }
         '''.stripIndent()
@@ -391,6 +389,21 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
 
         where:
         type << SONATYPE_PROJECT_TYPES
+    }
+
+    def 'does not check for signing keys when on a fork'() {
+        setup:
+        allPublishProjects()
+
+        when:
+        def executionResult = runTasksSuccessfully('publish',
+                '-P__TESTING_GPG_SIGNING_KEY=unset',
+                '-P__TESTING_GPG_SIGNING_KEY_ID=unset',
+                '-P__TESTING_GPG_SIGNING_KEY_PASSWORD=unset',
+                '-P__TESTING_CIRCLE_PR_USERNAME=forkyfork')
+
+        then:
+        executionResult.wasSkipped('checkSigningKey')
     }
 
     def 'fails build if publish if version ends in dirty'() {


### PR DESCRIPTION
## Before this PR
When an external contributor is contributing via a fork, we still check if the sonatype signing key is appropriately injected. This will never be on a fork, and publishing should never happen on a fork build as tags cannot be produced.

Example: https://github.com/palantir/gradle-docker/pull/460

## After this PR
==COMMIT_MSG==
Do not check for Sonatype signing key environment variables on fork builds.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
