### PR TITLE
Ensure that tests do not use environment variables from the actual build

### DIFF
--- a/changelog/@unreleased/pr-49.v2.yml
+++ b/changelog/@unreleased/pr-49.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Republish to fix internal build issue on tag builds.
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/49

--- a/src/main/java/com/palantir/gradle/externalpublish/EnvironmentVariables.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/EnvironmentVariables.java
@@ -23,14 +23,10 @@ final class EnvironmentVariables {
     private EnvironmentVariables() {}
 
     static Optional<String> envVarOrFromTestingProperty(Project project, String envVar) {
-        Optional<String> fromTestingProp = Optional.ofNullable((String) project.findProperty("__TESTING_" + envVar));
+        boolean isTesting = Optional.ofNullable((String) project.findProperty("__TESTING")).equals(Optional.of("true"));
 
-        if (fromTestingProp.equals(Optional.of("unset"))) {
-            return Optional.empty();
-        }
-
-        if (fromTestingProp.isPresent()) {
-            return fromTestingProp;
+        if (isTesting) {
+            return Optional.ofNullable((String) project.findProperty("__TESTING_" + envVar));
         }
 
         return Optional.ofNullable(System.getenv(envVar));

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -376,12 +376,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         publishProject(type)
 
         when:
-        def errorMessage = runTasksWithFailure(
-                        ":${type}:publish",
-                        '-P__TESTING_GPG_SIGNING_KEY=unset',
-                        '-P__TESTING_GPG_SIGNING_KEY_ID=unset',
-                        '-P__TESTING_GPG_SIGNING_KEY_PASSWORD=unset',
-                ).failure.cause.cause.message
+        def errorMessage = runTasksWithFailure(":${type}:publish").failure.cause.cause.message
 
         then:
         errorMessage == 'The required environment variables to sign the release could not be found. ' +
@@ -396,11 +391,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         allPublishProjects()
 
         when:
-        def executionResult = runTasksSuccessfully('publish',
-                '-P__TESTING_GPG_SIGNING_KEY=unset',
-                '-P__TESTING_GPG_SIGNING_KEY_ID=unset',
-                '-P__TESTING_GPG_SIGNING_KEY_PASSWORD=unset',
-                '-P__TESTING_CIRCLE_PR_USERNAME=forkyfork')
+        def executionResult = runTasksSuccessfully('publish', '-P__TESTING_CIRCLE_PR_USERNAME=forkyfork')
 
         then:
         executionResult.wasSkipped('checkSigningKey')
@@ -586,8 +577,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         return runTasksMethod(Stream.concat(Stream.of(
                     '-P__TESTING_GPG_SIGNING_KEY_ID=4F33301C',
                     "-P__TESTING_GPG_SIGNING_KEY=${Base64.getEncoder().encodeToString(privateKey)}",
-                    '-P__TESTING_GPG_SIGNING_KEY_PASSWORD=password',
-                    '-P__TESTING_CIRCLE_TAG=').map({ it.toString() }),
+                    '-P__TESTING_GPG_SIGNING_KEY_PASSWORD=password').map({ it.toString() }),
                 Stream.of(tasks)).toArray({new String[it] }))
     }
 
@@ -601,5 +591,10 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         }
 
         return executionResult
+    }
+
+    @Override
+    ExecutionResult runTasks(String... tasks) {
+        return super.runTasks(Stream.concat(Stream.of("-P__TESTING=true"), Stream.of(tasks)).toArray({ new String[it] }))
     }
 }


### PR DESCRIPTION
## Before this PR
The [most recent release failed](https://app.circleci.com/pipelines/github/palantir/gradle-external-publish-plugin/218/workflows/abc1f0cc-0a81-4854-bd69-7f62c62434a0), because it picked up the `CIRCLE_TAG` env var on the tag build and used that in tests.

## After this PR
Instead of picking up env vars in tests, we instead only look at `__TESTING_` prefixed gradle properties.

==COMMIT_MSG==
Republish to fix internal build issue on tag builds.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
