### PR TITLE
Disable publishing Gradle module metadata

### DIFF
--- a/changelog/@unreleased/pr-130.v2.yml
+++ b/changelog/@unreleased/pr-130.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable publishing Gradle module metadata
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/130

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -51,7 +51,7 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
         linkWithRootProject();
         disableOtherPublicationsFromPublishingToSonatype();
         // TODO(fwindheuser): Temporarily disable publishing module metadata.
-        // See TODO
+        // See: https://github.com/palantir/gradle-external-publish-plugin/pull/130
         disableModuleMetadata();
 
         // Sonatype requires we set a description on the pom, but the maven plugin will overwrite anything we set on

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -33,6 +33,7 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
+import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.plugins.signing.SigningExtension;
 import org.gradle.plugins.signing.SigningPlugin;
 
@@ -49,6 +50,9 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
         applyPublishingPlugins();
         linkWithRootProject();
         disableOtherPublicationsFromPublishingToSonatype();
+        // TODO(fwindheuser): Temporarily disable publishing module metadata.
+        // See TODO
+        disableModuleMetadata();
 
         // Sonatype requires we set a description on the pom, but the maven plugin will overwrite anything we set on
         // pom object. So we set the description on the project if it is not set, which the maven plugin reads from.
@@ -102,6 +106,13 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
                 return true;
             });
         });
+    }
+
+    private void disableModuleMetadata() {
+        // Turning off module metadata so that all consumers just use regular POMs
+        project.getTasks()
+                .withType(GenerateModuleMetadata.class)
+                .configureEach(generateModuleMetadata -> generateModuleMetadata.setEnabled(false));
     }
 
     public void addPublication(String publicationName, Action<MavenPublication> publicationConfiguration) {


### PR DESCRIPTION
## Before this PR
With https://github.com/palantir/gradle-external-publish-plugin/pull/109, we started publishing Gradle module metadata for our OSS projects. However we discovered some configuration mistakes in our internal repositories that would not sync the published ".module" files, resulting in inconsistent state. 

## After this PR
Plan is to disable publishing Gradle module metadata for our OSS projects for a while until most projects updated to a newly published version and then re-enable publishing module metadata files after fixing our internal repository sync.

==COMMIT_MSG==
Disable publishing Gradle module metadata
==COMMIT_MSG==