### PR TITLE
Re-enable gradle module metadata

### DIFF
--- a/changelog/@unreleased/pr-135.v2.yml
+++ b/changelog/@unreleased/pr-135.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Re-enable gradle module metadata
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/135

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -33,7 +33,6 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
-import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.plugins.signing.SigningExtension;
 import org.gradle.plugins.signing.SigningPlugin;
 
@@ -50,9 +49,6 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
         applyPublishingPlugins();
         linkWithRootProject();
         disableOtherPublicationsFromPublishingToSonatype();
-        // TODO(fwindheuser): Temporarily disable publishing module metadata.
-        // See: https://github.com/palantir/gradle-external-publish-plugin/pull/130
-        disableModuleMetadata();
 
         // Sonatype requires we set a description on the pom, but the maven plugin will overwrite anything we set on
         // pom object. So we set the description on the project if it is not set, which the maven plugin reads from.
@@ -106,13 +102,6 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
                 return true;
             });
         });
-    }
-
-    private void disableModuleMetadata() {
-        // Turning off module metadata so that all consumers just use regular POMs
-        project.getTasks()
-                .withType(GenerateModuleMetadata.class)
-                .configureEach(generateModuleMetadata -> generateModuleMetadata.setEnabled(false));
     }
 
     public void addPublication(String publicationName, Action<MavenPublication> publicationConfiguration) {


### PR DESCRIPTION
## Before this PR
We temporarily disabled publishing module metadata in https://github.com/palantir/gradle-external-publish-plugin/pull/130.

## After this PR
==COMMIT_MSG==
Re-enable gradle module metadata
==COMMIT_MSG==