### PR TITLE
Update the jar Implementation-Version lazily

### DIFF
--- a/changelog/@unreleased/pr-291.v2.yml
+++ b/changelog/@unreleased/pr-291.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Update the jar Implementation-Version lazily to avoid a race between
+    project initialization and application of the publishing plugin.
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/291

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
@@ -17,7 +17,7 @@
 package com.palantir.gradle.externalpublish;
 
 import java.util.Collections;
-import org.gradle.api.Action;
+import java.util.Objects;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaLibraryPlugin;
@@ -38,19 +38,32 @@ public class ExternalPublishJarPlugin implements Plugin<Project> {
     private static void configureJars(Project project) {
         project.getPluginManager().apply(JavaLibraryPlugin.class);
 
-        // Update the manifest Implementation-Version attribute after the project is evaluated, otherwise
-        // project version information may not be available yet.
-        project.afterEvaluate(new Action<Project>() {
-            @Override
-            public void execute(Project proj) {
-                proj.getTasks().withType(Jar.class).named("jar").configure(jar -> {
-                    jar.getManifest().attributes(Collections.singletonMap("Implementation-Version", proj.getVersion()));
-                });
-            }
+        project.getTasks().withType(Jar.class).named("jar").configure(jar -> {
+            jar.getManifest()
+                    .attributes(
+                            Collections.singletonMap("Implementation-Version", new ProjectVersionToString(project)));
         });
 
         JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
         javaPluginExtension.withJavadocJar();
         javaPluginExtension.withSourcesJar();
+    }
+
+    /**
+     * This is effectively a provider for the project version string value. The jar manifest may be configured
+     * before project versions have been set, particularly for subprojects which are configured via 'allprojects'
+     * or 'subprojects'.
+     */
+    private static final class ProjectVersionToString {
+        private final Project project;
+
+        private ProjectVersionToString(Project project) {
+            this.project = project;
+        }
+
+        @Override
+        public String toString() {
+            return Objects.toString(project.getVersion());
+        }
     }
 }


### PR DESCRIPTION
This avoids a race between project initialization and publishing plugin application.

==COMMIT_MSG==
Update the jar Implementation-Version in afterEvaluate to avoid a race between project initialization and application of the publishing plugin.
==COMMIT_MSG==

