### PR TITLE
AbstractPublishToMaven tasks depend on signing tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,3 +119,7 @@ javaVersions {
     runtime = 17
 }
 
+tasks.named('test') {
+    systemProperty 'ignoreDeprecations', 'true'
+}
+

--- a/changelog/@unreleased/pr-368.v2.yml
+++ b/changelog/@unreleased/pr-368.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: AbstractPublishToMaven tasks depend on signing tasks
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/368

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishGradlePluginPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishGradlePluginPlugin.java
@@ -31,6 +31,7 @@ public class ExternalPublishGradlePluginPlugin implements Plugin<Project> {
         project.getPluginManager().apply("java-gradle-plugin");
         // So we can get the publish task
         project.getPluginManager().apply("publishing");
+        project.getPluginManager().apply(ExternalPublishBasePlugin.class);
 
         try {
             project.getPluginManager().apply("com.gradle.plugin-publish");

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -126,7 +126,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
                 
                 gradlePlugin {
                     plugins {
-                        testPlugin {
+                        test {
                             id = 'com.palantir.testplugin'
                             implementationClass = 'com.palantir.external.TestPlugin'
                             displayName = 'TestPlugin Display'
@@ -576,7 +576,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         stdout.contains(':gradle-plugin:publishPluginMavenPublicationToSonatypeRepository SKIPPED')
-        stdout.contains(':gradle-plugin:publishTestPluginPluginMarkerMavenPublicationToSonatypeRepository SKIPPED')
+        stdout.contains(':gradle-plugin:publishTestPluginMarkerMavenPublicationToSonatypeRepository SKIPPED')
         stdout.contains(':gradle-plugin:publishMavenPublicationToSonatypeRepository UP-TO-DATE')
         stdout.contains(':gradle-plugin:publishPlugins UP-TO-DATE')
     }

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -549,7 +549,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         !result.standardError.contains("Gradle detected a problem")
 
         where:
-        gradleVersion << ['7.6.4', '8.5']
+        gradleVersion << ['8.6']
     }
 
     def 'publishes gradle plugins on publish on tag build'() {

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -121,8 +121,6 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
 
         if (type == 'gradle-plugin') {
             subprojectBuildGradle << '''
-                apply plugin: 'com.palantir.external-publish-gradle-plugin'
-                
                 gradlePlugin {
                     plugins {
                         test {
@@ -133,14 +131,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
                         }
                     }
                 }
-                
-                pluginBundle {
-                    website = 'https://example.com/'
-                    vcsUrl = 'https://example.com/'
-                    description = 'Test'
-                    tags = ['testing']
-                }
-            '''.stripIndent()
+            '''.stripIndent(true)
 
             writeJavaSourceFile('''
                 package com.palantir.external;
@@ -545,7 +536,6 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         ExecutionResult result = runSuccessfullyWithSigning('-P__TESTING_CIRCLE_TAG=tag', 'publishToMavenLocal')
 
         then:
-        result.success
         result.wasExecuted(":gradle-plugin:publishPluginMavenPublicationToMavenLocal")
         result.wasExecuted(":gradle-plugin:signMavenPublication")
         result.wasExecuted(":gradle-plugin:publishMavenPublicationToMavenLocal")

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -533,12 +533,12 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         stdout.contains(':gradle-plugin:publishPlugins SKIPPED')
     }
 
-    def 'fixes gradle#26091' () {
+    def 'fixes gradle#26091 with Gradle version #gradleVersion' () {
         setup:
         publishGradlePlugin()
 
         when:
-        ExecutionResult result = runSuccessfullyWithSigning('-P__TESTING_CIRCLE_TAG=tag', 'publishToMavenLocal', "--info", "--warning-mode=fail")
+        ExecutionResult result = runSuccessfullyWithSigning('-P__TESTING_CIRCLE_TAG=tag', 'publishToMavenLocal')
 
         then:
         result.success
@@ -547,6 +547,9 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted(":gradle-plugin:signMavenPublication")
         result.wasExecuted(":gradle-plugin:publishMavenPublicationToMavenLocal")
         !result.standardError.contains("Gradle detected a problem")
+
+        where:
+        gradleVersion << ['7.6.4', '8.5']
     }
 
     def 'publishes gradle plugins on publish on tag build'() {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Failures in gradle 8.5 projects that are publishing multiple external publications: see [circleCi failure](https://app.circleci.com/pipelines/github/palantir/gradle-failure-reports/27/workflows/324669f0-72af-46c6-b01a-33612660b0ff/jobs/53)

```
Some problems were found with the configuration of task ':gradle-failure-reports:signPluginMavenPublication' (type 'Sign').
  - Gradle detected a problem with the following location: '/home/circleci/project/gradle-failure-reports/build/libs/gradle-failure-reports-1.1.0-javadoc.jar.asc'.
    
    Reason: Task ':gradle-failure-reports:publishMavenPublicationToSonatypeRepository' uses this output of task ':gradle-failure-reports:signPluginMavenPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

In `gradle-failure-reports` we have 2 publications: `maven` and `pluginMaven` which both generate the same artifact.  Each publication has a `sign` task, both sign tasks write to the same output and clobber each other. Gradle thinks each one of the publish tasks for the publication is using the output of the wrong sign task so complains.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Workaround for implicit dependency [gradle#26091](https://github.com/gradle/gradle/issues/26091)

If the signing plugin is applied, then the publishing tasks `AbstractPublishToMaven` will depend on `Sign` tasks. 
==COMMIT_MSG==
AbstractPublishToMaven tasks depend on signing tasks
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

