### PR TITLE
disable javaLanucher for test task

### DIFF
--- a/changelog/@unreleased/pr-460.v2.yml
+++ b/changelog/@unreleased/pr-460.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: disable javaLanucher for test task
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/460

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishIntellijPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishIntellijPlugin.java
@@ -59,7 +59,7 @@ public class ExternalPublishIntellijPlugin implements Plugin<Project> {
             projectAfterEvaluate.getTasks().withType(JavaExec.class).named("runIde", task -> {
                 task.getJavaLauncher().set((JavaLauncher) null);
             });
-            projectAfterEvaluate.getTasks().named("test", Test.class, task -> {
+            projectAfterEvaluate.getTasks().withType(Test.class).named("test", task -> {
                 task.getJavaLauncher().set((JavaLauncher) null);
             });
         });

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishIntellijPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishIntellijPlugin.java
@@ -20,6 +20,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.jetbrains.intellij.IntelliJPlugin;
@@ -56,6 +57,9 @@ public class ExternalPublishIntellijPlugin implements Plugin<Project> {
 
         project.afterEvaluate(projectAfterEvaluate -> {
             projectAfterEvaluate.getTasks().withType(JavaExec.class).named("runIde", task -> {
+                task.getJavaLauncher().set((JavaLauncher) null);
+            });
+            projectAfterEvaluate.getTasks().named("test", Test.class, task -> {
                 task.getJavaLauncher().set((JavaLauncher) null);
             });
         });


### PR DESCRIPTION
## Before this PR
Test tasks for intellij plugins would cause the following error:

```
Toolchain from `executable` property does not match toolchain from `javaLauncher` property.
```


## After this PR
This commit works around that issue
