### PR TITLE
Make `ExternalPublishJarPlugin` configuration-cache compatible

### DIFF
--- a/changelog/@unreleased/pr-600.v2.yml
+++ b/changelog/@unreleased/pr-600.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make ExternalPublishJarPlugin configuration-cache friendly
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/600

--- a/changelog/@unreleased/pr-600.v2.yml
+++ b/changelog/@unreleased/pr-600.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Make ExternalPublishJarPlugin configuration-cache friendly
+  description: Make ExternalPublishJarPlugin configuration-cache compatible
   links:
   - https://github.com/palantir/gradle-external-publish-plugin/pull/600

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
@@ -36,6 +36,9 @@ public class ExternalPublishJarPlugin implements Plugin<Project> {
 
     private static void configureJars(Project project) {
         project.getPluginManager().apply(JavaLibraryPlugin.class);
+
+        // The jar manifest may be configured before project versions have been set,
+        // particularly for subprojects which are configured via 'allprojects' or 'subprojects'.
         Provider<String> versionProvider =
                 project.provider(() -> project.getVersion().toString());
 

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
@@ -17,7 +17,6 @@
 package com.palantir.gradle.externalpublish;
 
 import java.util.Collections;
-import java.util.Objects;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaLibraryPlugin;
@@ -55,7 +54,7 @@ public class ExternalPublishJarPlugin implements Plugin<Project> {
      **/
     private record ToStringProvider(String string) {
 
-    @Override
+        @Override
         public String toString() {
             return string;
         }

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
@@ -37,11 +37,12 @@ public class ExternalPublishJarPlugin implements Plugin<Project> {
 
     private static void configureJars(Project project) {
         project.getPluginManager().apply(JavaLibraryPlugin.class);
+        String projectVersion = project.getVersion().toString();
 
         project.getTasks().withType(Jar.class).named("jar").configure(jar -> {
             jar.getManifest()
                     .attributes(
-                            Collections.singletonMap("Implementation-Version", new ProjectVersionToString(project)));
+                            Collections.singletonMap("Implementation-Version", new ToStringProvider(projectVersion)));
         });
 
         JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
@@ -50,20 +51,13 @@ public class ExternalPublishJarPlugin implements Plugin<Project> {
     }
 
     /**
-     * This is effectively a provider for the project version string value. The jar manifest may be configured
-     * before project versions have been set, particularly for subprojects which are configured via 'allprojects'
-     * or 'subprojects'.
-     */
-    private static final class ProjectVersionToString {
-        private final Project project;
+     * Mocks the value expected in Implementation-Version
+     **/
+    private record ToStringProvider(String string) {
 
-        private ProjectVersionToString(Project project) {
-            this.project = project;
-        }
-
-        @Override
+    @Override
         public String toString() {
-            return Objects.toString(project.getVersion());
+            return string;
         }
     }
 }

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishJarPlugin.java
@@ -21,10 +21,10 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Provider;
 import org.gradle.jvm.tasks.Jar;
 
 public class ExternalPublishJarPlugin implements Plugin<Project> {
-
     @Override
     public final void apply(Project project) {
         configureJars(project);
@@ -36,27 +36,15 @@ public class ExternalPublishJarPlugin implements Plugin<Project> {
 
     private static void configureJars(Project project) {
         project.getPluginManager().apply(JavaLibraryPlugin.class);
-        String projectVersion = project.getVersion().toString();
+        Provider<String> versionProvider =
+                project.provider(() -> project.getVersion().toString());
 
         project.getTasks().withType(Jar.class).named("jar").configure(jar -> {
-            jar.getManifest()
-                    .attributes(
-                            Collections.singletonMap("Implementation-Version", new ToStringProvider(projectVersion)));
+            jar.getManifest().attributes(Collections.singletonMap("Implementation-Version", versionProvider));
         });
 
         JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
         javaPluginExtension.withJavadocJar();
         javaPluginExtension.withSourcesJar();
-    }
-
-    /**
-     * Mocks the value expected in Implementation-Version
-     **/
-    private record ToStringProvider(String string) {
-
-        @Override
-        public String toString() {
-            return string;
-        }
     }
 }

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ConfigurationCacheTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ConfigurationCacheTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.externalpublish
+
+import nebula.test.IntegrationTestKitSpec
+
+class ConfigurationCacheTest extends IntegrationTestKitSpec {
+
+    def setup() {
+        definePluginOutsideOfPluginBlock = true
+        keepFiles = true
+    }
+
+    def "classes task runs with configuration cache when applying ExternalPublishJarPlugin"() {
+        given:
+        setupBuildWithGitVersion("""
+            apply plugin: 'com.palantir.external-publish-jar'
+            apply plugin: 'java-library'
+
+            repositories {
+                mavenCentral()
+                mavenLocal()
+            }
+        """)
+
+        expect:
+        runTasksWithConfigurationCache('classes')
+    }
+
+    /**
+     * Sets up the build.gradle file with the given content.
+     */
+    private void setupBuildWithGitVersion(String buildFileContent) {
+        // language=Gradle
+        buildFile << buildFileContent.stripIndent(true)
+    }
+
+    /**
+     * Runs the specified tasks twice with configuration cache and verifies cache behavior.
+     * Returns true if the configuration cache was properly used on the second run.
+     */
+    private boolean runTasksWithConfigurationCache(String... tasks) {
+        def firstRun = createRunner(tasks + ['--configuration-cache'] as String[]).build()
+        assert firstRun.output.contains('Configuration cache entry stored.'),
+                "Expected first run to store configuration cache, but output was: ${firstRun.output}"
+
+        def secondRun = createRunner(tasks + ['--configuration-cache'] as String[]).build()
+        assert secondRun.output.contains('Configuration cache entry reused.'),
+                "Expected second run to reuse configuration cache, but output was: ${secondRun.output}"
+
+        return true
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We are making gradle-conjure configuration-cache friendly. The first step is to get `./gradlew classes --configuration-cache to work` to work on gradle-conjure. Running the command raises a few errors in the build scan, including one originating from ExternalPublishJarPlugin:

```
- task `:gradle-conjure-api:jar` of type `org.gradle.api.tasks.bundling.Jar`
    - field `manifest` of `org.gradle.api.tasks.bundling.Jar`
        - bean of type `org.gradle.api.java.archives.internal.DefaultManifest`
            - field `attributes` of `org.gradle.api.java.archives.internal.DefaultManifest`
                - bean of type `org.gradle.api.java.archives.internal.DefaultAttributes`
                    - field `attributes` of `org.gradle.api.java.archives.internal.DefaultAttributes`
                        - bean of type `com.palantir.gradle.externalpublish.ExternalPublishJarPlugin$ProjectVersionToString`
                            - field `project` of `com.palantir.gradle.externalpublish.ExternalPublishJarPlugin$ProjectVersionToString`
                                - [error] cannot serialize object of type `org.gradle.api.internal.project.DefaultProject`, a subtype of `org.gradle.api.Project`, as these are not supported with the configuration cache
```

`ExternalPublishJarPlugin` invokes getProject() when configuring the `jar` task. [The project object cannot be referred to by tasks for configuration cacheing to work](https://docs.gradle.org/current/userguide/configuration_cache.html#gradle_model_types). By removing this reference to project, `ExternalPublishJarPlugin` now works with the configuration cache. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

`ExternalPublishJarPlugin` is configuration-cache friendly, allowing `./gradlew classes --configuration-cache` to work on  gradle-conjure 

==COMMIT_MSG==
Make `ExternalPublishJarPlugin` configuration-cache friendly
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

