### PR TITLE
just do normal com.netflix.nebula.maven-publish include now

### DIFF
--- a/changelog/@unreleased/pr-641.v2.yml
+++ b/changelog/@unreleased/pr-641.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: just do normal com.netflix.nebula.maven-publish include now
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/641

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -19,11 +19,6 @@ package com.palantir.gradle.externalpublish;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
-import nebula.plugin.info.scm.ScmInfoPlugin;
-import nebula.plugin.publishing.maven.MavenBasePublishPlugin;
-import nebula.plugin.publishing.maven.MavenManifestPlugin;
-import nebula.plugin.publishing.maven.MavenScmPlugin;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
@@ -31,7 +26,6 @@ import org.gradle.api.Project;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
-import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven;
 import org.gradle.api.publish.maven.tasks.PublishToMavenLocal;
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
@@ -52,7 +46,7 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
     public void apply(Project projectVal) {
         this.project = projectVal;
 
-        applyPublishingPlugins();
+        project.getPluginManager().apply("com.netflix.nebula.maven-publish");
         linkWithRootProject();
         disableOtherPublicationsFromPublishingToSonatype();
         disableModuleMetadata();
@@ -64,18 +58,6 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
         if (project.getDescription() == null) {
             project.setDescription("Palantir open source project");
         }
-    }
-
-    private void applyPublishingPlugins() {
-        // Intentionally not applying nebula.maven-publish, but most of its constituent plugins,
-        // because we do _not_ want nebula.maven-compile-only
-        Stream.of(
-                        MavenPublishPlugin.class,
-                        MavenBasePublishPlugin.class,
-                        MavenManifestPlugin.class,
-                        MavenScmPlugin.class,
-                        ScmInfoPlugin.class)
-                .forEach(plugin -> project.getPluginManager().apply(plugin));
     }
 
     private void linkWithRootProject() {


### PR DESCRIPTION
## Before this PR
The custom code we use to apply most of the  com.netflix.nebula.maven-publish because it didn't want the compile-only plugin was from many, many years ago.  Something has changed in how the ScmInfo plugin works in v14 ([here](https://github.com/nebula-plugins/gradle-info-plugin/pull/107)) that now causes the custom setup steps to fail, blocking the version upgrade [PR](https://github.com/palantir/gradle-external-publish-plugin/pull/537).  The compile-only plugin no longer exists, so should be safe to switch to just a normal apply statement.  I tested this together with the version bumps in another [PR](https://github.com/palantir/gradle-external-publish-plugin/pull/642/files) and things work.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

