### PR TITLE
Ensure we're putting url and scmUrl in pom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.69.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.21.0'
         classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.11.0'
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.22.0'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.21.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.14.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.73.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.12.0'

--- a/changelog/@unreleased/pr-654.v2.yml
+++ b/changelog/@unreleased/pr-654.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix OSS publishing by ensuring we're putting `url` and `scm.url` in
+    pom.
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/654

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -19,6 +19,11 @@ package com.palantir.gradle.externalpublish;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
+import nebula.plugin.info.scm.ScmInfoPlugin;
+import nebula.plugin.publishing.maven.MavenBasePublishPlugin;
+import nebula.plugin.publishing.maven.MavenManifestPlugin;
+import nebula.plugin.publishing.maven.MavenScmPlugin;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
@@ -26,6 +31,7 @@ import org.gradle.api.Project;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven;
 import org.gradle.api.publish.maven.tasks.PublishToMavenLocal;
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
@@ -46,7 +52,7 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
     public void apply(Project projectVal) {
         this.project = projectVal;
 
-        project.getPluginManager().apply("com.netflix.nebula.maven-publish");
+        applyNebulaPublishingPlugins();
         linkWithRootProject();
         disableOtherPublicationsFromPublishingToSonatype();
         disableModuleMetadata();
@@ -58,6 +64,22 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
         if (project.getDescription() == null) {
             project.setDescription("Palantir open source project");
         }
+    }
+
+    private void applyNebulaPublishingPlugins() {
+        // Intentionally not applying nebula.maven-publish, but most of its constituent plugins,
+        // because we generally do not want to add new nebula plugins without reviewing them first.
+        Stream.of(
+                        MavenPublishPlugin.class,
+                        MavenBasePublishPlugin.class,
+                        MavenManifestPlugin.class,
+                        // TODO(callumr): Replace this nebula plugin with our internal version that handle ssh
+                        //                remotes properly - ie changing them to http remotes in the pom
+                        MavenScmPlugin.class,
+                        // We need this in the subproject as well as the root project as the subproject plugin
+                        // reads the root project extension to save loading the same git info many times
+                        ScmInfoPlugin.class)
+                .forEach(plugin -> project.getPluginManager().apply(plugin));
     }
 
     private void linkWithRootProject() {

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishRootPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishRootPlugin.java
@@ -22,6 +22,7 @@ import io.github.gradlenexus.publishplugin.NexusPublishPlugin;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
+import nebula.plugin.info.scm.ScmInfoPlugin;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -39,6 +40,10 @@ public class ExternalPublishRootPlugin implements Plugin<Project> {
             throw new GradleException("The " + ExternalPublishRootPlugin.class.getSimpleName()
                     + " plugin must be applied on the root project");
         }
+
+        // This is required to be applied to the root project so the nebula MavenScmPlugin will work properly
+        // on subprojects
+        rootProject.getPluginManager().apply(ScmInfoPlugin.class);
 
         rootProject.getPluginManager().apply(NexusPublishPlugin.class);
         NexusPublishExtension publishExtension = rootProject.getExtensions().getByType(NexusPublishExtension.class);

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -375,23 +375,23 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
 
 
         then:
-        ['foo', 'bar'].each { name ->
-            def gnv = new File(mavenRepoDir, "group/${name}/version")
-            verifyPomFile(gnv, name)
+        ['foo', 'bar'].each { artifactId ->
+            def gnv = new File(mavenRepoDir, "group/${artifactId}/version")
+            verifyPomFile(gnv, artifactId)
 
-            new File(gnv, "${name}-version.gradle").exists()
+            assert new File(gnv, "${artifactId}-version.gradle").exists()
         }
     }
 
-    void verifyPomFile(File gnv, String name) {
-        verifyPomFile(gnv, name, 'version')
+    void verifyPomFile(File gnv, String artifactId) {
+        verifyPomFile(gnv, artifactId, 'version')
     }
 
-    void verifyPomFile(File gnv, String name, String version) {
-        def pom = new XmlParser().parse(new File(gnv, "${name}-${version}.pom"))
+    void verifyPomFile(File gnv, String artifactId, String version) {
+        def pom = new XmlParser().parse(new File(gnv, "${artifactId}-${version}.pom"))
 
         assert pom.groupId.text() == 'group'
-        assert pom.name.text() == name
+        assert pom.artifactId.text() == artifactId
         assert pom.version.text() == version
         // Sonatype requires a description
         assert !pom.description.text().isEmpty()

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -390,23 +390,23 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
     void verifyPomFile(File gnv, String name, String version) {
         def pom = new XmlParser().parse(new File(gnv, "${name}-${version}.pom"))
 
-        pom.groupId.text() == 'group'
-        pom.name.text() == name
-        pom.version.text() == version
+        assert pom.groupId.text() == 'group'
+        assert pom.name.text() == name
+        assert pom.version.text() == version
         // Sonatype requires a description
-        !pom.description.text().isEmpty()
-        pom.url.text().endsWith 'gradle-external-publish-plugin'
+        assert !pom.description.text().isEmpty()
+        assert pom.url.text().endsWith('gradle-external-publish-plugin')
 
         def license = pom.licenses.license
-        license.name.text() == 'The Apache License, Version 2.0'
-        license.url.text() == 'https://www.apache.org/licenses/LICENSE-2.0'
+        assert license.name.text() == 'The Apache License, Version 2.0'
+        assert license.url.text() == 'https://www.apache.org/licenses/LICENSE-2.0'
 
         def developer = pom.developers.developer
-        developer.id.text() == 'palantir'
-        developer.name.text() == 'Palantir Technologies Inc'
-        developer.organizationUrl.text() == 'https://www.palantir.com'
+        assert developer.id.text() == 'palantir'
+        assert developer.name.text() == 'Palantir Technologies Inc'
+        assert developer.organizationUrl.text() == 'https://www.palantir.com'
 
-        pom.scm.url.text().endsWith 'gradle-external-publish-plugin.git'
+        assert pom.scm.url.text().endsWith('gradle-external-publish-plugin.git')
     }
 
     File testingMavenRepo() {


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/gradle-external-publish-plugin/pull/641, we changed up how we apply the nebula plugins. However, this stopped applying the nebula `ScmInfoPlugin`, which means that the `NebulaScmPlugin` _does nothing_, as it has a `withPlugin`. This causes publishes to fail as we no longer have the `url` and `scm.url` fields in the `pom.xml`:

<img width="1042" height="638" alt="Screenshot 2025-08-04 at 14 04 46" src="https://github.com/user-attachments/assets/4df0a6ce-6197-4620-abd2-65aaa9513365" />

Part of this regressions was that the tests were not good - they did not fail when their assertions failed (bad groovy footgun).

We also started applying more Nebula plugins by applying the overall nebula publish plugin, which applies everything they have. I think this is the wrong direction for us - ideally we'd make our own plugins that fit our own needs rather than continue to rely Nebula's plugins which often have breaks or changes which are not relevant to us.

## After this PR
==COMMIT_MSG==
Fix OSS publishing by ensuring we're putting `url` and `scm.url` in pom.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

