### PR TITLE
Use even older plugin version to actually publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.69.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.21.0'
         classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.11.0'
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.21.0'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.19.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.14.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.73.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.12.0'

--- a/changelog/@unreleased/pr-655.v2.yml
+++ b/changelog/@unreleased/pr-655.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Republish to fix publish failures
+  links:
+  - https://github.com/palantir/gradle-external-publish-plugin/pull/655


### PR DESCRIPTION
## Before this PR
The previous publish of this plugin failed for the reason listed in #654:

<img width="587" height="193" alt="Screenshot 2025-08-04 at 17 19 22" src="https://github.com/user-attachments/assets/dd841015-8870-4f0d-bfb2-5b44f86edc20" />

We're not using an old enough version of this plugin to publish itself without bugs.

## After this PR
==COMMIT_MSG==
Republish to fix publish failures
==COMMIT_MSG==

I checked the pom this time:

```
  <url>git@github.com:palantir/gradle-external-publish-plugin</url>
  <scm>
    <url>git@github.com:palantir/gradle-external-publish-plugin</url>
  </scm>
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

