### PR TITLE
Add a `BOM` plugin to allow use to use Gradle Module Metadata for transitive version alignment in the `buildScript`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 Source and javadoc jars will be published automatically. Additionally, `Implementation-Version` will be added to Jar manifest, based on the Gradle project version.
 
+## Publishing BOMs (Bill of Materials)
+
+Apply the `com.palantir.external-publish-bom` plugin to publish a BOM that manages versions for your published artifacts:
+
+```gradle
+apply plugin: 'com.palantir.external-publish-bom'
+```
+
+This plugin automatically:
+- Creates a Java platform (BOM) that declares version constraints for all sibling projects that use `com.palantir.external-publish-jar`
+- Adds the BOM as a platform dependency to each jar project, ensuring version alignment
+
+### Why this matters
+
+The plugin publishes [Gradle Module Metadata](https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html) which solves a critical gap: **buildScript transitive version conflicts**.
+
+While gradle-consistent-versions manages regular dependencies, it doesn't apply to buildScript classpath. This causes runtime failures when plugins pull in incompatible transitive versions. The BOM's platform constraints in Gradle Module Metadata ensure all transitives align to compatible versions.
+
 ## Publishing Application Dists
 
 Apply the `com.palantir.external-publish-application-dist` to publish an executable Java application distribution `.tgz` based on the Gradle `application` plugin:

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,13 @@ gradlePlugin {
             implementationClass = 'com.palantir.gradle.externalpublish.ExternalPublishCustomPlugin'
             tags.set(['publishing'])
         }
+        externalPublishBom {
+            id = 'com.palantir.external-publish-bom'
+            displayName = 'Palantir External Publish Bom Plugin'
+            description = pluginDescription('a jar bom')
+            implementationClass = 'com.palantir.gradle.externalpublish.ExternalPublishBomPlugin'
+            tags.set(['publishing'])
+        }
     }
 }
 

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -49,7 +49,7 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
         project.getPluginManager().apply("com.netflix.nebula.maven-publish");
         linkWithRootProject();
         disableOtherPublicationsFromPublishingToSonatype();
-        disableModuleMetadata();
+        conditionallyDisableModuleMetadata();
         publishToMavenLocalAsPartOfBuild();
         addSignPublishDependency();
 
@@ -95,11 +95,20 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
         });
     }
 
-    private void disableModuleMetadata() {
-        // Turning off module metadata so that all consumers just use regular POMs
-        project.getTasks()
-                .withType(GenerateModuleMetadata.class)
-                .configureEach(generateModuleMetadata -> generateModuleMetadata.setEnabled(false));
+    private void conditionallyDisableModuleMetadata() {
+        // Only disable module metadata if no BOM plugin is present in any subproject
+        // The BOM plugin requires GMM for proper version alignment
+        project.afterEvaluate(proj -> {
+            boolean hasBomPlugin = proj.getRootProject().getSubprojects().stream()
+                    .anyMatch(subproject -> subproject.getPlugins().hasPlugin(ExternalPublishBomPlugin.class));
+
+            if (!hasBomPlugin) {
+                // Turning off module metadata so that all consumers just use regular POMs
+                proj.getTasks()
+                        .withType(GenerateModuleMetadata.class)
+                        .configureEach(generateModuleMetadata -> generateModuleMetadata.setEnabled(false));
+            }
+        });
     }
 
     private void publishToMavenLocalAsPartOfBuild() {

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -29,7 +29,6 @@ import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven;
 import org.gradle.api.publish.maven.tasks.PublishToMavenLocal;
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
-import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.plugins.signing.Sign;
@@ -49,7 +48,6 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
         project.getPluginManager().apply("com.netflix.nebula.maven-publish");
         linkWithRootProject();
         disableOtherPublicationsFromPublishingToSonatype();
-        conditionallyDisableModuleMetadata();
         publishToMavenLocalAsPartOfBuild();
         addSignPublishDependency();
 
@@ -92,22 +90,6 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
 
                 return true;
             });
-        });
-    }
-
-    private void conditionallyDisableModuleMetadata() {
-        // Only disable module metadata if no BOM plugin is present in any subproject
-        // The BOM plugin requires GMM for proper version alignment
-        project.afterEvaluate(proj -> {
-            boolean hasBomPlugin = proj.getRootProject().getSubprojects().stream()
-                    .anyMatch(subproject -> subproject.getPlugins().hasPlugin(ExternalPublishBomPlugin.class));
-
-            if (!hasBomPlugin) {
-                // Turning off module metadata so that all consumers just use regular POMs
-                proj.getTasks()
-                        .withType(GenerateModuleMetadata.class)
-                        .configureEach(generateModuleMetadata -> generateModuleMetadata.setEnabled(false));
-            }
         });
     }
 

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBomPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBomPlugin.java
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.externalpublish;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class ExternalPublishBomPlugin implements Plugin<Project> {
+    @Override
+    public final void apply(Project project) {
+        project.getPluginManager().apply("java-platform");
+        //        project.getPluginManager().apply(MavenPublishPlugin.class);
+
+        configurePlatformConstraints(project);
+
+        ExternalPublishBasePlugin.applyTo(project)
+                .addPublication(
+                        "bom", maven -> maven.from(project.getComponents().getByName("javaPlatform")));
+    }
+
+    private void configurePlatformConstraints(Project project) {
+        project.getDependencies().constraints(constraints -> {
+            project.getRootProject().getSubprojects().forEach(subproject -> {
+                if (!subproject.equals(project)) {
+                    if (subproject.getPlugins().hasPlugin(ExternalPublishJarPlugin.class)) {
+                        constraints.add("api", project.project(subproject.getPath()));
+                        addPlatformToSubproject(subproject, project);
+                    }
+                }
+            });
+        });
+    }
+
+    private void addPlatformToSubproject(Project subproject, Project platformProject) {
+        subproject.getDependencies().add("api", subproject.getDependencies().platform(platformProject));
+    }
+}

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBomPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBomPlugin.java
@@ -23,7 +23,6 @@ public class ExternalPublishBomPlugin implements Plugin<Project> {
     @Override
     public final void apply(Project project) {
         project.getPluginManager().apply("java-platform");
-        //        project.getPluginManager().apply(MavenPublishPlugin.class);
 
         configurePlatformConstraints(project);
 

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -101,6 +101,10 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         publishProject('custom')
     }
 
+    File publishBom() {
+        publishProject('bom', 'platform-bom')
+    }
+
     File publishProject(String type, String subprojectName = type) {
         def subprojectDir = new File(projectDir, subprojectName)
 
@@ -729,6 +733,68 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         then:
         def postText = new File("versions.lock").text
         assert emptyText == postText
+    }
+
+    def 'can apply bom plugin and creates platform publication'() {
+        setup:
+        publishBom()
+
+        when:
+        ExecutionResult result = runTasksSuccessfully(':platform-bom:tasks', '--all')
+
+        then:
+        result.standardOutput.contains('publishBomPublicationToMavenLocal')
+        result.standardOutput.contains('generatePomFileForBomPublication')
+    }
+
+    def 'subprojects with external-publish-jar get platform dependency added'() {
+        setup:
+        // Create BOM project
+        publishBom()
+        publishJar()
+
+        when:
+        def result = runTasksSuccessfully(':jar:dependencies', '--configuration', 'api')
+
+        then:
+        result.standardOutput.contains('-- project platform-bom')
+    }
+
+    def 'can published module metadata is correct'() {
+        setup:
+        publishBom()
+        publishJar()
+        def mavenRepoDir = testingMavenRepo()
+
+        when:
+        runTasksSuccessfully('publishBomPublicationToTestRepoRepository')
+
+        then:
+        def gnv = new File(mavenRepoDir, 'group/platform-bom/version')
+        def module = new File(gnv, 'platform-bom-version.module')
+        module.exists()
+
+        module.text.contains('"dependencyConstraints"')
+        module.text.contains('"group": "group"')
+        module.text.contains('"module": "jar"')
+        module.text.contains('"requires": "version"')
+
+        verifyPomFile(gnv, 'platform-bom')
+
+        when:
+        runTasksSuccessfully('publishMavenPublicationToTestRepoRepository')
+
+        then:
+        def gnvJar = new File(mavenRepoDir, 'group/jar/version')
+        def moduleJar = new File(gnvJar, 'jar-version.module')
+        moduleJar.exists()
+
+        moduleJar.text.contains('"dependencies"')
+        moduleJar.text.contains('"group": "group"')
+        moduleJar.text.contains('"module": "platform-bom"')
+        moduleJar.text.contains('"requires": "version"')
+        moduleJar.text.contains('"org.gradle.category": "platform"')
+        moduleJar.text.contains('"endorseStrictVersions": true')
     }
 
     private void disableAllTaskActions() {

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -767,7 +767,7 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         def mavenRepoDir = testingMavenRepo()
 
         when:
-        runTasksSuccessfully('publishBomPublicationToTestRepoRepository')
+        runTasksSuccessfully('publishBomPublicationToTestRepoRepository', 'publishMavenPublicationToTestRepoRepository')
 
         then:
         def gnv = new File(mavenRepoDir, 'group/platform-bom/version')
@@ -781,10 +781,6 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
 
         verifyPomFile(gnv, 'platform-bom')
 
-        when:
-        runTasksSuccessfully('publishMavenPublicationToTestRepoRepository')
-
-        then:
         def gnvJar = new File(mavenRepoDir, 'group/jar/version')
         def moduleJar = new File(gnvJar, 'jar-version.module')
         moduleJar.exists()


### PR DESCRIPTION
## Before this PR
Currently, we have no way of aligning the versions of transitive dependencies in the `buildScript` classpath, which can result in runtime failures. See: https://pl.ntr/2wI

For example, if you have two Gradle plugins with conflicting transitive dependencies:
```gradle
buildscript {
    dependencies {
        classpath 'foo:5.0.0'  // depends on errorprone 2.18.0
        classpath 'bar:6.0.0' // depends on errorprone 2.10.0
    }
}
```

This can lead to runtime errors like:
```
java.lang.NoSuchMethodError: 'com.google.errorprone.ErrorProneOptions$Builder 
com.google.errorprone.ErrorProneOptions.processArgs(java.lang.Iterable)'
```

While `gradle-consistent-versions` manages regular project dependencies, it doesn't apply to the buildScript classpath, leaving a critical gap in version management.

## After this PR
After evaluating options, implementing a BOM-based solution similar to Jackson's approach.

This PR introduces `com.palantir.external-publish-bom`, a plugin that:
1. Creates a Java platform (BOM) declaring version constraints for all sibling projects using `ExternalPublishJarPlugin`
2. Automatically adds the BOM as a platform dependency to each jar project
3. **Enables Gradle Module Metadata publication** (previously disabled)

This results in the following being added to each subproject's Gradle Module Metadata:
```json
"dependencies": [
  {
    "group": "group",
    "module": "<project>-bom",
    "version": {
      "requires": "version"
    },
    "attributes": {
      "org.gradle.category": "platform"
    },
    "endorseStrictVersions": true
  }
]
```

The platform constraints ensure version alignment across all subprojects, preventing transitive dependency conflicts in  buildScript classpaths when consumers use the published artifacts.

==COMMIT_MSG==
Add BOM plugin for buildScript transitive version alignment via Gradle Module Metadata

Introduces `com.palantir.external-publish-bom` plugin that publishes a BOM with Gradle Module Metadata to solve buildScript classpath version conflicts that gradle-consistent-versions cannot handle.
==COMMIT_MSG==

## Possible downsides?
- **Gradle Module Metadata will now be published** (previously always disabled). While this enables the version alignment feature, it may affect consumers using older Gradle versions (<5.3) that don't support GMM.
- Projects must explicitly apply the BOM plugin to benefit from this feature
- The GMM produced in the Jar subprojects include `dependencyConstraints` from gradle-cosnsitent-versions see https://github.com/palantir/gradle-consistent-versions/blob/develop/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java#L956