### PR TITLE
Allow publishing of gradle module metadata to be togglable 

### DIFF
--- a/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/SharedProperties.java
+++ b/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/SharedProperties.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.publish;
+
+public final class SharedProperties {
+    public static final String PUBLISH_MODULE_METADATA_PROPERTY = "publishModuleMetadata";
+
+    private SharedProperties() {}
+}

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -43,6 +43,7 @@ import org.gradle.plugins.signing.SigningExtension;
 import org.gradle.plugins.signing.SigningPlugin;
 
 final class ExternalPublishBasePlugin implements Plugin<Project> {
+    private static final String PUBLISH_MODULE_METADATA_PROPERTY = "com.palantir.externalpublish.publishModuleMetadata";
 
     private final Set<String> sonatypePublicationNames = new HashSet<>();
 
@@ -118,6 +119,11 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
     }
 
     private void disableModuleMetadata() {
+        if (project.hasProperty(PUBLISH_MODULE_METADATA_PROPERTY)
+                && "true".equals(project.findProperty(PUBLISH_MODULE_METADATA_PROPERTY))) {
+            return;
+        }
+
         // Turning off module metadata so that all consumers just use regular POMs
         project.getTasks()
                 .withType(GenerateModuleMetadata.class)

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.externalpublish;
 
+import com.palantir.gradle.publish.SharedProperties;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -43,7 +44,6 @@ import org.gradle.plugins.signing.SigningExtension;
 import org.gradle.plugins.signing.SigningPlugin;
 
 final class ExternalPublishBasePlugin implements Plugin<Project> {
-    private static final String PUBLISH_MODULE_METADATA_PROPERTY = "publishModuleMetadata";
 
     private final Set<String> sonatypePublicationNames = new HashSet<>();
 
@@ -119,8 +119,8 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
     }
 
     private void disableModuleMetadata() {
-        if (project.hasProperty(PUBLISH_MODULE_METADATA_PROPERTY)
-                && "true".equals(project.findProperty(PUBLISH_MODULE_METADATA_PROPERTY))) {
+        if (project.hasProperty(SharedProperties.PUBLISH_MODULE_METADATA_PROPERTY)
+                && "true".equals(project.findProperty(SharedProperties.PUBLISH_MODULE_METADATA_PROPERTY))) {
             return;
         }
 

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -43,7 +43,7 @@ import org.gradle.plugins.signing.SigningExtension;
 import org.gradle.plugins.signing.SigningPlugin;
 
 final class ExternalPublishBasePlugin implements Plugin<Project> {
-    private static final String PUBLISH_MODULE_METADATA_PROPERTY = "com.palantir.externalpublish.publishModuleMetadata";
+    private static final String PUBLISH_MODULE_METADATA_PROPERTY = "publishModuleMetadata";
 
     private final Set<String> sonatypePublicationNames = new HashSet<>();
 


### PR DESCRIPTION
## Before this PR
Always disabled GMM

## After this PR
Now can toggle it on via a gradle property `publishModuleMetadata` this is a prerequisite to using GMM 
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow publishing of gradle module metadata to be togglable 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

