### PR TITLE
Remove code no longer needed for Gradle plugin publishing plugin 2.0.0

### DIFF
--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishGradlePluginPlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishGradlePluginPlugin.java
@@ -17,11 +17,9 @@
 package com.palantir.gradle.externalpublish;
 
 import com.palantir.gradle.publish.GradlePluginMetaDataPlugin;
-import com.palantir.gradle.utils.environmentvariables.EnvironmentVariables;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.UnknownPluginException;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -51,15 +49,5 @@ public class ExternalPublishGradlePluginPlugin implements Plugin<Project> {
         });
 
         project.getPluginManager().apply(GradlePluginMetaDataPlugin.class);
-
-        EnvironmentVariables envVars = OurEnvironmentVariables.environmentVariables(project);
-
-        ExtraPropertiesExtension extraProperties = project.getExtensions().getExtraProperties();
-        extraProperties.set(
-                "gradle.publish.key",
-                envVars.envVarOrFromTestingProperty("GRADLE_KEY").getOrNull());
-        extraProperties.set(
-                "gradle.publish.secret",
-                envVars.envVarOrFromTestingProperty("GRADLE_SECRET").getOrNull());
     }
 }

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishGradlePluginPluginSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishGradlePluginPluginSpec.groovy
@@ -45,7 +45,7 @@ class ExternalPublishGradlePluginPluginSpec extends IntegrationSpec {
                 }
                 
                 dependencies {
-                    classpath 'com.gradle.publish:plugin-publish-plugin:1.3.0'
+                    classpath 'com.gradle.publish:plugin-publish-plugin:2.0.0'
                 }
             }
 


### PR DESCRIPTION
## Before this PR
The `plugin-plublishing-plugin` that publishes Gradle plugins to the Gradle plugin portal has been upgraded to 2.0.0 across all our repos.

Unfortunately, this seems to have broken publishing as the credentials are not configured - [example failure](https://app.circleci.com/pipelines/github/palantir/gradle-conjure/4841/workflows/00a47d51-905c-4cab-a6c5-6c950edb0b9f/jobs/18534?invite=true#step-104-20579_151):

> Caused by: java.lang.IllegalArgumentException: Missing publishing keys. Please set gradle.publish.key/gradle.publish.secret system properties or GRADLE_PUBLISH_KEY/GRADLE_PUBLISH_SECRET env variables or login using the login task.

We were previously doing something very hacky to set the `gradle.publish.key/secret` gradle properties - setting them on `ExtraPropertiesExtension` from some environment variable values. Now the plugin upgraded to 2.0.0 they have made it configuration cache compatible, and I think the new api they are using to get the gradle property no longer looks in `ExtraPropertiesExtension`.

I think we were using Gradle properties before because there was no built in way to use environment variables. However, the plugin can [now be configured with env vars rather than just Gradle properties](https://plugins.gradle.org/docs/publish-plugin#:~:text=Alternatively%2C%20you%20can%20provide%20the%20API%20key%20via%20GRADLE_PUBLISH_KEY%20and%20GRADLE_PUBLISH_SECRET%20environment%20variables.).

We've updated our infra to set these env vars directly.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Delete code that is no longer necessary to set the credentials for publishing to the Gradle publishing portal.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

