### PR TITLE
Fix noisy `MavenScmPlugin` warnings for SSH git remotes

### DIFF
--- a/publish-plugin-lib/build.gradle
+++ b/publish-plugin-lib/build.gradle
@@ -7,7 +7,9 @@ dependencies {
 
     api gradleApi()
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'
 
+    testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/PalantirMavenScmPlugin.java
+++ b/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/PalantirMavenScmPlugin.java
@@ -1,0 +1,144 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.publish;
+
+import com.google.common.base.Strings;
+import groovy.util.Node;
+import groovy.util.NodeList;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.inject.Inject;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.process.ExecOutput;
+
+/**
+ * A replacement for nebula's MavenScmPlugin that correctly converts SSH git remotes to HTTPS URLs
+ * in the POM file. The nebula plugin logs warnings when encountering SSH remotes; this plugin
+ * handles them properly by converting git@host:org/repo style URLs to https://host/org/repo.
+ */
+public abstract class PalantirMavenScmPlugin implements Plugin<Project> {
+
+    private static final Logger log = Logging.getLogger(PalantirMavenScmPlugin.class);
+
+    private static final Object SCM_BRANCH_KEY = "originBranch";
+
+    private static final Pattern ORIGIN_URL_PATTERN = Pattern.compile(
+            "((git|ssh|https?):(//))?(\\w+@)?(?<domainOwner>[\\w.@\\-~]+)([:\\\\/])(?<repo>[\\w.@:/\\-~]+?)"
+                    + "(\\.git)?(/)?");
+
+    @Inject
+    @SuppressWarnings("JavaxInjectOnAbstractMethod") // Gradle's recommended pattern for service injection in plugins
+    protected abstract ProviderFactory getProviderFactory();
+
+    @Override
+    public final void apply(Project project) {
+        if (insideTmpDir(project.getRootDir())) {
+            return;
+        }
+
+        Provider<String> originUrl = getOriginUrl(project.getRootDir());
+        Provider<String> branch = getBranch(project.getRootDir());
+
+        project.getExtensions().getByType(PublishingExtension.class).publications(publications -> publications
+                .withType(MavenPublication.class)
+                .configureEach(mavenPublication -> mavenPublication.pom(mavenPom -> {
+                    mavenPom.getUrl().set(originUrl.map(PalantirMavenScmPlugin::calculateUrlFromOriginUrl));
+                    mavenPom.scm(mavenPomScm -> mavenPomScm.getUrl().set(originUrl));
+                    mavenPom.withXml(xmlProvider -> {
+                        Node rootNode = xmlProvider.asNode();
+                        NodeList propertiesList = (NodeList) rootNode.get("properties");
+                        Node propertiesNode = propertiesList.isEmpty()
+                                ? rootNode.appendNode("properties")
+                                : (Node) propertiesList.get(0);
+                        propertiesNode.appendNode(SCM_BRANCH_KEY, branch.get());
+                    });
+                })));
+    }
+
+    private Provider<String> getOriginUrl(File rootDir) {
+        return runCommand(rootDir, "git", "config", "remote.origin.url");
+    }
+
+    private Provider<String> getBranch(File rootDir) {
+        return runCommand(rootDir, "git", "branch", "--show", "current")
+                .map(Strings::emptyToNull)
+                .orElse(runCommand(rootDir, "git", "rev-parse", "HEAD"));
+    }
+
+    private Provider<String> runCommand(File rootDir, String... command) {
+        ExecOutput output = getProviderFactory().exec(execSpec -> {
+            execSpec.commandLine((Object[]) command);
+            execSpec.workingDir(rootDir);
+            execSpec.setIgnoreExitValue(true);
+        });
+
+        record OutputStreams(String stdOut, String stdErr) {}
+
+        Provider<OutputStreams> outputStreams = output.getStandardOutput()
+                .getAsText()
+                .zip(output.getStandardError().getAsText(), OutputStreams::new);
+
+        return output.getResult().zip(outputStreams, (result, streams) -> {
+            if (result.getExitValue() != 0) {
+                throw new RuntimeException(String.format(
+                        Locale.ROOT, "Exited with code %d:\n\n%s", result.getExitValue(), streams.stdErr()));
+            }
+            return streams.stdOut().trim();
+        });
+    }
+
+    static String calculateUrlFromOriginUrl(String originUrl) {
+        Matcher matcher = ORIGIN_URL_PATTERN.matcher(originUrl);
+
+        if (matcher.matches()) {
+            return String.format("https://%s/%s", matcher.group("domainOwner"), matcher.group("repo"));
+        } else {
+            return originUrl;
+        }
+    }
+
+    private static boolean insideTmpDir(File rootDir) {
+        // Some repos roll their own testing using junit, like gradle-baseline. These put the gradle build in a
+        // temporary directory instead of build.
+
+        try {
+            // We must use toRealPath() here as macos has a symlink from /var -> /private/var
+            Path canonicalTmpDir =
+                    Paths.get(System.getProperty("java.io.tmpdir")).toRealPath();
+            Path canonicalRootDir = rootDir.toPath().toRealPath();
+
+            return canonicalRootDir.startsWith(canonicalTmpDir);
+        } catch (IOException e) {
+            // Don't fail the build because of this, as this is the prime way to make it say only fail in the
+            // excavator execution environment - just make an obnoxious log message
+            log.error("Failed to determine if build is inside tmp dir", e);
+            return false;
+        }
+    }
+}

--- a/publish-plugin-lib/src/test/java/com/palantir/gradle/publish/PalantirMavenScmPluginTest.java
+++ b/publish-plugin-lib/src/test/java/com/palantir/gradle/publish/PalantirMavenScmPluginTest.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.publish;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PalantirMavenScmPluginTest {
+    @ParameterizedTest
+    @MethodSource("expected_urls")
+    void calculates_correct_https_urls_from_origin(TestCase testCase) {
+        assertThat(PalantirMavenScmPlugin.calculateUrlFromOriginUrl(testCase.input))
+                .isEqualTo(testCase.expectedOutput);
+    }
+
+    static Stream<TestCase> expected_urls() {
+        return Stream.of(
+                // HTTPS URLs
+                new TestCase("https://github.com/palantir/repo.git", "https://github.com/palantir/repo"),
+                new TestCase("https://github.com/palantir/repo.git/", "https://github.com/palantir/repo"),
+                new TestCase("https://gitlab.com/org/repo.git", "https://gitlab.com/org/repo"),
+                new TestCase("https://gitlab.com/org/repo.git/", "https://gitlab.com/org/repo"),
+                new TestCase("https://foobar@github.com/palantir/repo.git", "https://github.com/palantir/repo"),
+                // SSH URLs (git@ style)
+                new TestCase("git@github.com:palantir/repo.git", "https://github.com/palantir/repo"),
+                new TestCase("git@github.com:palantir/repo.git/", "https://github.com/palantir/repo"),
+                new TestCase("git@gitlab.com:org/repo.git", "https://gitlab.com/org/repo"),
+                new TestCase("git@github.com:palantir/repo", "https://github.com/palantir/repo"),
+                new TestCase("git@gitlab.com:org/repo.git/", "https://gitlab.com/org/repo"),
+                // SSH URLs (ssh:// style)
+                new TestCase("ssh://git@github.com/palantir/repo.git", "https://github.com/palantir/repo"),
+                new TestCase("ssh://github.com/palantir/repo.git", "https://github.com/palantir/repo"),
+                // Enterprise GitHub (subdomains)
+                new TestCase("https://github.example.com/org/repo.git", "https://github.example.com/org/repo"),
+                new TestCase("git@github.example.com:org/repo.git", "https://github.example.com/org/repo"),
+                // Invalid URL passthrough
+                new TestCase("invalid_url", "invalid_url"),
+                // GitLab nested groups/subgroups
+                new TestCase("git@gitlab.com:org/subgroup/repo.git", "https://gitlab.com/org/subgroup/repo"),
+                new TestCase("https://gitlab.com/org/subgroup/repo.git", "https://gitlab.com/org/subgroup/repo"));
+    }
+
+    private static final class TestCase {
+        private final String input;
+        private final String expectedOutput;
+
+        TestCase(String input, String expectedOutput) {
+            this.input = input;
+            this.expectedOutput = expectedOutput;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s -> %s", input, expectedOutput);
+        }
+    }
+}

--- a/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
+++ b/src/main/java/com/palantir/gradle/externalpublish/ExternalPublishBasePlugin.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.externalpublish;
 
+import com.palantir.gradle.publish.PalantirMavenScmPlugin;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -23,7 +24,6 @@ import java.util.stream.Stream;
 import nebula.plugin.info.scm.ScmInfoPlugin;
 import nebula.plugin.publishing.maven.MavenBasePublishPlugin;
 import nebula.plugin.publishing.maven.MavenManifestPlugin;
-import nebula.plugin.publishing.maven.MavenScmPlugin;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
@@ -73,9 +73,9 @@ final class ExternalPublishBasePlugin implements Plugin<Project> {
                         MavenPublishPlugin.class,
                         MavenBasePublishPlugin.class,
                         MavenManifestPlugin.class,
-                        // TODO(callumr): Replace this nebula plugin with our internal version that handle ssh
-                        //                remotes properly - ie changing them to http remotes in the pom
-                        MavenScmPlugin.class,
+                        // Our own PalantirMavenScmPlugin that handles ssh remotes properly - converting them to
+                        // https URLs in the pom
+                        PalantirMavenScmPlugin.class,
                         // We need this in the subproject as well as the root project as the subproject plugin
                         // reads the root project extension to save loading the same git info many times
                         ScmInfoPlugin.class)

--- a/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/externalpublish/ExternalPublishRootPluginIntegrationSpec.groovy
@@ -406,7 +406,12 @@ class ExternalPublishRootPluginIntegrationSpec extends IntegrationSpec {
         assert developer.name.text() == 'Palantir Technologies Inc'
         assert developer.organizationUrl.text() == 'https://www.palantir.com'
 
-        assert pom.scm.url.text().endsWith('gradle-external-publish-plugin.git')
+        // The scm.url is the raw git remote origin - may or may not have .git suffix
+        assert pom.scm.url.text().contains('gradle-external-publish-plugin')
+
+        // PalantirMavenScmPlugin adds the originBranch property
+        assert pom.properties.originBranch.text() != null
+        assert !pom.properties.originBranch.text().isEmpty()
     }
 
     File testingMavenRepo() {


### PR DESCRIPTION
## Before this PR

The nebula `MavenScmPlugin` logs warnings when it encounters SSH git remotes (e.g., `git@github.com:org/repo.git`):

```
Unable to convert git@github.com:palantir/gradle-external-publish-plugin to https form in MavenScmPlugin. Using original value.
```

This warning is logged for every subproject in a build, making it very noisy. It also consumes extra tokens when working with AI coding agents that read build output.

This was [fixed internally](https://pl.ntr/2z9) first.

## After this PR

No more noisy warnings when using SSH git remotes.

Adds `PalantirMavenScmPlugin` (code essentially identical to the [internal PR](https://pl.ntr/2z9), with test cases sanitised for public GitHub) which:
- Properly converts SSH git remotes to HTTPS URLs in POM files
- Sets `pom.url` to the HTTPS URL derived from the git remote
- Sets `pom.scm.url` to the original git remote URL
- Adds the `originBranch` property to the POM

The internal repo will [use this shared implementation](https://pl.ntr/2za).

## Testing

Manually tested by publishing to maven local and verifying:
- No warning logs when running `MAVEN_LOCAL=external-publish ./gradlew generatePomFileForMavenPublication`
- Generated POM has correct `<url>` (HTTPS), `<scm><url>` (original SSH), and `<originBranch>` property

## Possible downsides?

## Possible alternatives?