### PR TITLE
Update PalantirMavenScmPlugin to use GitVersionCacheService

### DIFF
--- a/publish-plugin-lib/build.gradle
+++ b/publish-plugin-lib/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api gradleApi()
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.gradle.gitversion:gradle-git-version'
     implementation 'com.palantir.safe-logging:preconditions'
 
     testImplementation 'org.assertj:assertj-core'

--- a/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/PalantirMavenScmPlugin.java
+++ b/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/PalantirMavenScmPlugin.java
@@ -16,14 +16,14 @@
 
 package com.palantir.gradle.publish;
 
-import com.google.common.base.Strings;
+import com.palantir.gradle.gitversion.GitVersionCacheService;
+import com.palantir.gradle.gitversion.VersionDetails;
 import groovy.util.Node;
 import groovy.util.NodeList;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
@@ -36,7 +36,6 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
-import org.gradle.process.ExecOutput;
 
 /**
  * A replacement for nebula's MavenScmPlugin that correctly converts SSH git remotes to HTTPS URLs
@@ -65,8 +64,16 @@ public abstract class PalantirMavenScmPlugin implements Plugin<Project> {
             return;
         }
 
-        Provider<String> originUrl = getOriginUrl(project.getRootDir());
-        Provider<String> branch = getBranch(project.getRootDir());
+        Provider<VersionDetails> versionDetails = GitVersionCacheService.getSharedGitVersionCacheService(project)
+                .map(cacheService -> cacheService.getVersionDetails(project.getProjectDir(), null));
+        Provider<String> originUrl = versionDetails.map(VersionDetails::getOriginUrl);
+        Provider<String> branch = versionDetails.map(details -> {
+            try {
+                return details.getBranchName();
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to get branchName from GitVersionCacheService", e);
+            }
+        });
 
         project.getExtensions().getByType(PublishingExtension.class).publications(publications -> publications
                 .withType(MavenPublication.class)
@@ -82,38 +89,6 @@ public abstract class PalantirMavenScmPlugin implements Plugin<Project> {
                         propertiesNode.appendNode(SCM_BRANCH_KEY, branch.get());
                     });
                 })));
-    }
-
-    private Provider<String> getOriginUrl(File rootDir) {
-        return runCommand(rootDir, "git", "config", "remote.origin.url");
-    }
-
-    private Provider<String> getBranch(File rootDir) {
-        return runCommand(rootDir, "git", "branch", "--show", "current")
-                .map(Strings::emptyToNull)
-                .orElse(runCommand(rootDir, "git", "rev-parse", "HEAD"));
-    }
-
-    private Provider<String> runCommand(File rootDir, String... command) {
-        ExecOutput output = getProviderFactory().exec(execSpec -> {
-            execSpec.commandLine((Object[]) command);
-            execSpec.workingDir(rootDir);
-            execSpec.setIgnoreExitValue(true);
-        });
-
-        record OutputStreams(String stdOut, String stdErr) {}
-
-        Provider<OutputStreams> outputStreams = output.getStandardOutput()
-                .getAsText()
-                .zip(output.getStandardError().getAsText(), OutputStreams::new);
-
-        return output.getResult().zip(outputStreams, (result, streams) -> {
-            if (result.getExitValue() != 0) {
-                throw new RuntimeException(String.format(
-                        Locale.ROOT, "Exited with code %d:\n\n%s", result.getExitValue(), streams.stdErr()));
-            }
-            return streams.stdOut().trim();
-        });
     }
 
     static String calculateUrlFromOriginUrl(String originUrl) {

--- a/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/PalantirMavenScmPlugin.java
+++ b/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/PalantirMavenScmPlugin.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.publish;
 
 import com.palantir.gradle.gitversion.GitVersionCacheService;
 import com.palantir.gradle.gitversion.VersionDetails;
+import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
 import groovy.util.Node;
 import groovy.util.NodeList;
 import java.io.File;
@@ -71,7 +72,7 @@ public abstract class PalantirMavenScmPlugin implements Plugin<Project> {
             try {
                 return details.getBranchName();
             } catch (IOException e) {
-                throw new RuntimeException("Failed to get branchName from GitVersionCacheService", e);
+                throw new SafeUncheckedIoException("Failed to get branchName from GitVersionCacheService", e);
             }
         });
 

--- a/versions.lock
+++ b/versions.lock
@@ -14,7 +14,7 @@ com.google.errorprone:error_prone_annotations:2.41.0 (3 constraints: 8120f448)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 
-com.google.guava:guava:33.5.0-jre (4 constraints: 1156f720)
+com.google.guava:guava:33.5.0-jre (5 constraints: 7b6c1f06)
 
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
 
@@ -31,6 +31,8 @@ com.netflix.nebula:gradle-info-plugin:16.0.1 (2 constraints: e3172872)
 com.netflix.nebula:nebula-gradle-interop:3.1.0 (1 constraints: e60f3d97)
 
 com.netflix.nebula:nebula-publishing-plugin:23.0.0 (1 constraints: 37053c3b)
+
+com.palantir.gradle.gitversion:gradle-git-version:4.3.0 (1 constraints: 09050836)
 
 com.palantir.gradle.utils:environment-variables:0.21.0 (1 constraints: 35052a3b)
 

--- a/versions.props
+++ b/versions.props
@@ -7,6 +7,7 @@ com.netflix.nebula:gradle-info-plugin = 16.0.1
 org.junit.platform:* = 6.0.2
 org.rauschig:jarchivelib = 1.1.0
 com.google.guava:guava = 33.5.0-jre
+com.palantir.gradle.gitversion:gradle-git-version = 4.3.0
 com.palantir.gradle.utils:environment-variables = 0.21.0
 com.palantir.safe-logging:preconditions = 3.11.0
 org.jetbrains.intellij.plugins:gradle-intellij-plugin = 1.17.3


### PR DESCRIPTION
## Summary 

Refactors `PalantirMavenScmPlugin` to use the existing `GitVersionCacheService ` instead of executing `git` commands directly.
  
## Benefits 
- Leverages existing, well-tested `git` integration
- Better integration with Gradle's configuration cache and lazy evaluation 


<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update PalantirMavenScmPlugin to use GitVersionCacheService
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

