### PR TITLE
Fix `generatePluginMetaData` failing when no plugins are defined

### DIFF
--- a/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/GenerateGradlePluginMetaDataTask.java
+++ b/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/GenerateGradlePluginMetaDataTask.java
@@ -19,23 +19,20 @@ package com.palantir.gradle.publish;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.CacheableTask;
-import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
@@ -53,9 +50,9 @@ public abstract class GenerateGradlePluginMetaDataTask extends DefaultTask {
         getOutputFile().convention(getProject().getLayout().getBuildDirectory().file(getName() + ".json"));
     }
 
-    @InputDirectory
+    @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    public abstract DirectoryProperty getPluginDescDirectory();
+    public abstract ConfigurableFileCollection getPluginDescriptorFiles();
 
     @OutputFile
     public abstract RegularFileProperty getOutputFile();
@@ -74,23 +71,13 @@ public abstract class GenerateGradlePluginMetaDataTask extends DefaultTask {
     }
 
     /**
-     * Scan the generated gradle-plugins directory and get the set of all plugin ids and implementing class names.
+     * Scan the plugin descriptor files and get the set of all plugin ids and implementing class names.
      */
     private Set<GradlePluginDef> getPluginDefs() {
-        File gradlePluginsDescriptorDir = getPluginDescDirectory().get().getAsFile();
-
-        if (!gradlePluginsDescriptorDir.exists()) {
-            return Collections.emptySet();
-        }
-
-        try (Stream<Path> walk = Files.walk(gradlePluginsDescriptorDir.toPath(), 1)) {
-            return walk.filter(Files::isRegularFile)
-                    .filter(file -> file.getFileName().toString().endsWith(".properties"))
-                    .map(file -> GradlePluginDef.of(getPluginId(file), getImplementationClass(file)))
-                    .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(GradlePluginDef::id))));
-        } catch (IOException e) {
-            throw new SafeUncheckedIoException(e);
-        }
+        return getPluginDescriptorFiles().getFiles().stream()
+                .filter(file -> file.getName().endsWith(".properties"))
+                .map(file -> GradlePluginDef.of(getPluginId(file.toPath()), getImplementationClass(file.toPath())))
+                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(GradlePluginDef::id))));
     }
 
     /**

--- a/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/GradlePluginMetaDataPlugin.java
+++ b/publish-plugin-lib/src/main/java/com/palantir/gradle/publish/GradlePluginMetaDataPlugin.java
@@ -18,10 +18,10 @@ package com.palantir.gradle.publish;
 
 import groovy.util.Node;
 import groovy.util.NodeList;
+import java.io.File;
 import java.util.Optional;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
@@ -60,17 +60,20 @@ public final class GradlePluginMetaDataPlugin implements Plugin<Project> {
 
             TaskProvider<ProcessResources> processResources =
                     project.getTasks().named(mainSourceSet.getProcessResourcesTaskName(), ProcessResources.class);
-            DirectoryProperty resourcesDirectory = project.getObjects()
-                    .directoryProperty()
-                    .fileProvider(processResources.map(ProcessResources::getDestinationDir));
 
             TaskProvider<GenerateGradlePluginMetaDataTask> generatePluginMdTask = project.getTasks()
                     .register(
                             GenerateGradlePluginMetaDataTask.TASK_NAME,
                             GenerateGradlePluginMetaDataTask.class,
-                            task -> task.getPluginDescDirectory()
-                                    .set(resourcesDirectory.map(
-                                            resources -> resources.dir("META-INF/gradle-plugins"))));
+                            task -> {
+                                // Use a file tree that gracefully handles missing directories.
+                                // The directory may not exist if java-gradle-plugin is applied but no
+                                // plugins are defined (e.g., when using gradle-plugin-testing for tests).
+                                task.getPluginDescriptorFiles().from(processResources.map(pr -> {
+                                    File pluginDescDir = new File(pr.getDestinationDir(), "META-INF/gradle-plugins");
+                                    return project.fileTree(pluginDescDir, tree -> tree.include("*.properties"));
+                                }));
+                            });
 
             // Because the GeneratePom task is an UntrackedTask, it doesn't know that another task needs to run in order
             // to provide all of its inputs.  So we have to force the dependsOn.

--- a/src/test/java/com/palantir/gradle/externalpublish/ExternalPublishGradlePluginPluginTest.java
+++ b/src/test/java/com/palantir/gradle/externalpublish/ExternalPublishGradlePluginPluginTest.java
@@ -172,6 +172,30 @@ class ExternalPublishGradlePluginPluginTest {
                 .containsExactly(tuple("com.palantir.test-plugin1", "com.palantir.gradle.TestPlugin1"));
     }
 
+    @Test
+    void succeeds_when_no_plugins_defined(GradleInvoker gradle, RootProject rootProject) throws Exception {
+        // No gradlePlugin block, no properties files - simulates applying java-gradle-plugin
+        // without defining any plugins (e.g., when using gradle-plugin-testing for tests only)
+
+        InvocationResult result =
+                gradle.withArgs("generatePomFileForPluginMavenPublication").buildsSuccessfully();
+
+        // processResources may be NO_SOURCE if there are no resources
+        assertThat(result).task(":generatePluginMetaData").succeeded();
+        rootProject
+                .buildDir()
+                .file("publications/pluginMaven/pom-default.xml")
+                .assertThat()
+                .exists();
+
+        PomProject pom =
+                parsePomFile(rootProject.buildDir().path().resolve("publications/pluginMaven/pom-default.xml"));
+        List<GradlePluginDef> publishedPlugins =
+                OBJECT_MAPPER.readValue(pom.properties().publishedPluginIds(), GRADLE_PLUGIN_DEF_TYPE_REF);
+
+        assertThat(publishedPlugins).as("Empty list when no plugins defined").isEmpty();
+    }
+
     private PomProject parsePomFile(Path xmlFile) throws Exception {
         return XML_MAPPER.readValue(xmlFile.toFile(), PomProject.class);
     }


### PR DESCRIPTION
## Before this PR

When `java-gradle-plugin` is applied but no plugins are defined (e.g., when using `gradle-plugin-testing` for tests only), the `META-INF/gradle-plugins` directory doesn't exist. The `generatePluginMetaData` task would fail with:

```
property 'pluginDescDirectory' specifies directory 
'.../build/resources/main/META-INF/gradle-plugins' which doesn't exist.
```

This happens because `@InputDirectory` requires the directory to exist, even though the task itself has code to handle missing directories.

## After this PR

Changed `GenerateGradlePluginMetaDataTask` to use `ConfigurableFileCollection` with a file tree that gracefully handles missing directories. The task now:
- Succeeds when no plugins are defined
- Produces an empty JSON array `[]` in that case

## Testing

Added test case `succeeds_when_no_plugins_defined` that verifies the fix.

## Possible downsides?

None expected - this is purely making the task more robust to handle a valid use case.
